### PR TITLE
Remove stray top-level expression from RootLayout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -31,4 +31,3 @@ export default function RootLayout({
     </html>
   );
 }
-0


### PR DESCRIPTION
## Summary
- Removes a stray `0` that sat after the closing brace of `RootLayout` in `app/layout.tsx`
- The expression was harmless (not rendered) but was junk left from an earlier edit

## Test plan
- [x] No functional change — layout renders as before
- [ ] Visual smoke check on deploy preview